### PR TITLE
[WIP] Prepare for Debian “bullseye” Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:11.0-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILD_CORES

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG BUILD_CORES

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN NB_CORES=${BUILD_CORES-$(getconf _NPROCESSORS_CONF)} \
     libsodium-dev" \
  && apt-get update && apt-get install -y -q --no-install-recommends \
     ${BUILD_DEPS} \
-    libevent-2.1-6 \
+    libevent-2.1-7 \
     libglib2.0-0 \
     libssl1.1 \
     libmagic1 \


### PR DESCRIPTION
Prepare to update to bullseye.

This builds fine. Using this image as the base for mailserver also builds fine but about 10 tests are failing. I have not looked into what causes them to fail.

This PR is still a draft and should only be merged when bullseye is released and the tests work.